### PR TITLE
Fix group scan exploit

### DIFF
--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/command/commands/InvitePlayer.java
@@ -59,15 +59,6 @@ public class InvitePlayer extends PlayerCommandMiddle{
 			s.sendMessage(ChatColor.RED + "The player has never played before.");
 			return true;
 		}
-		if (group.isCurrentMember(targetAccount)) { // So a player can't demote someone who is above them.
-			s.sendMessage(ChatColor.RED + "Player is already a member. "
-					+ "Use /promoteplayer to change their PlayerType.");
-			return true;
-		}
-		if(NameLayerPlugin.getBlackList().isBlacklisted(group, targetAccount)) {
-			s.sendMessage(ChatColor.RED + "This player is currently blacklisted, you have to unblacklist him with /removeblacklist before inviting him to the group");
-			return true;
-		}
 		final PlayerType pType = targetType != null ? PlayerType.getPlayerType(targetType) : PlayerType.MEMBERS;
 		if (pType == null) {
 			if (p != null) {
@@ -81,6 +72,7 @@ public class InvitePlayer extends PlayerCommandMiddle{
 			p.sendMessage(ChatColor.RED + "I think we both know that this shouldn't be possible.");
 			return true;
 		}
+		boolean allowed = false;
 		if (!isAdmin) {
 			// Perform access check
 			final UUID executor = p.getUniqueId();
@@ -89,7 +81,6 @@ public class InvitePlayer extends PlayerCommandMiddle{
 				s.sendMessage(ChatColor.RED + "You are not on that group.");
 				return true;
 			}
-			boolean allowed = false;
 			switch (pType) { // depending on the type the executor wants to add the player to
 				case MEMBERS:
 					allowed = gm.hasAccess(group, executor, PermissionType.getPermission("MEMBERS"));
@@ -111,13 +102,23 @@ public class InvitePlayer extends PlayerCommandMiddle{
 				s.sendMessage(ChatColor.RED + "You do not have permissions to modify this group.");
 				return true;
 			}
+		}
+		if (group.isCurrentMember(targetAccount)) { // So a player can't demote someone who is above them.
+			s.sendMessage(ChatColor.RED + "Player is already a member. "
+					+ "Use /promoteplayer to change their PlayerType.");
+			return true;
+		}
+		if(NameLayerPlugin.getBlackList().isBlacklisted(group, targetAccount)) {
+			s.sendMessage(ChatColor.RED + "This player is currently blacklisted, you have to unblacklist him with /removeblacklist before inviting him to the group");
+			return true;
+		}
+		if (!isAdmin) {
 			sendInvitation(group, pType, targetAccount, p.getUniqueId(), true);
 			Mercury.addInvite(group.getGroupId(), pType.toString(), targetAccount, p.getUniqueId().toString());
 		} else {
 			sendInvitation(group, pType, targetAccount, null, true);
 			Mercury.addInvite(group.getGroupId(), pType.toString(), targetAccount, null);
 		}
-
 		s.sendMessage(ChatColor.GREEN + "The invitation has been sent." + "\n Use /revoke to Revoke an invite.");
 		return true;
 	}


### PR DESCRIPTION
The nlip command currently suffers from a bug that allows scanning groups for who is a member. This edit should solve the problem by reordering the permission check to before checking for if the player is in the group already.