### PR TITLE
Fixed bug where blacklisted players could join password protected groups

### DIFF
--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/command/commands/JoinGroup.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/command/commands/JoinGroup.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 
 import vg.civcraft.mc.namelayer.GroupManager.PlayerType;
 import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.command.PlayerCommandMiddle;
 import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.GroupPermission;
@@ -59,6 +60,11 @@ public class JoinGroup extends PlayerCommandMiddle{
 			p.sendMessage(ChatColor.RED + "You are already a member.");
 			return true;
 		}
+		if(NameLayerPlugin.getBlackList().isBlacklisted(g, uuid)) {
+			p.sendMessage(ChatColor.RED + "You can not join a group you have been blacklisted from");
+			return true;
+		}
+
 		g.addMember(uuid, pType);
 		p.sendMessage(ChatColor.GREEN + "You have successfully been added to this group.");
 		return true;

--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/gui/GUIGroupOverview.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/gui/GUIGroupOverview.java
@@ -397,11 +397,17 @@ public class GUIGroupOverview {
 									Group gro = ensureFreshGroup(g);
 									GroupPermission groupPerm = gm.getPermissionforGroup(gro);
 									PlayerType pType = groupPerm.getFirstWithPerm(PermissionType.getPermission("JOIN_PASSWORD"));
-									if (pType == null){
+									if (pType == null) {
 										p.sendMessage(ChatColor.RED + "Someone derped. This group does not have the specified permission to let you join, sorry.");
 										showScreen();
 										return;
 									}
+									if (NameLayerPlugin.getBlackList().isBlacklisted(gro, p.getUniqueId())) {
+										p.sendMessage(ChatColor.RED + "You can not join a group you have been blacklisted from");
+										showScreen();
+										return;
+									}
+
 									NameLayerPlugin.log(Level.INFO,
 											p.getName() + " joined with password "
 													+ " to group " + g.getName()


### PR DESCRIPTION
Prior to this commit, blacklisting players from password protected groups would have no effect as the JoinGroup command didn't check if said player was blacklisted or not.