### PR TITLE
MojangNames + Permission Sorting

### DIFF
--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/MojangNames.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/MojangNames.java
@@ -1,0 +1,121 @@
+package vg.civcraft.mc.namelayer;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.civrepo.commons.holders.MoreMapUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+import org.bukkit.Bukkit;
+import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.scheduler.BukkitTask;
+import vg.civcraft.mc.civmodcore.serialization.NBTCompound;
+import vg.civcraft.mc.namelayer.listeners.AssociationListener;
+
+public final class MojangNames {
+
+	private static final Map<String, UUID> PROFILES = Collections.synchronizedMap(
+			new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+	private static final String PROFILES_FILE = "mojang.dat";
+	private static final long SAVE_DELAY = 20 * 60; // 60 seconds' worth of ticks
+	private static BukkitTask SAVE_TASK;
+
+	public static void init(final NameLayerPlugin plugin) {
+		final Path mojangFile = plugin.getResourceFile(PROFILES_FILE).toPath();
+		// Load all the profiles that already exist
+		Bukkit.getScheduler().runTaskAsynchronously(
+				plugin, () -> load(plugin, mojangFile));
+		// Set up a process of saving profiles
+		SAVE_TASK = Bukkit.getScheduler().runTaskTimerAsynchronously(
+				plugin, () -> save(plugin, mojangFile), SAVE_DELAY, SAVE_DELAY);
+	}
+
+	public static void reset(final NameLayerPlugin plugin) {
+		if (!PROFILES.isEmpty()) {
+			save(plugin, plugin.getResourceFile(PROFILES_FILE).toPath());
+			PROFILES.clear();
+		}
+		if (SAVE_TASK != null) {
+			SAVE_TASK.cancel();
+			SAVE_TASK = null;
+		}
+	}
+
+	private static void load(final NameLayerPlugin plugin, final Path file) {
+		PROFILES.clear();
+		try {
+			final byte[] data = Files.readAllBytes(file);
+			final NBTCompound nbt = NBTCompound.fromBytes(data);
+			nbt.getKeys().forEach(key -> PROFILES.put(key, nbt.getUUID(key)));
+			plugin.info("[MojangNames] Mojang profiles loaded!");
+		}
+		catch (final NoSuchFileException ignored) {}
+		catch (final IOException exception) {
+			plugin.warning("[MojangNames] Could not load Mojang profiles!", exception);
+		}
+	}
+
+	private static void save(final NameLayerPlugin plugin, final Path file) {
+		final NBTCompound nbt = new NBTCompound();
+		PROFILES.forEach(nbt::setUUID);
+		final byte[] data = NBTCompound.toBytes(nbt);
+		try {
+			Files.write(file, data,
+					StandardOpenOption.CREATE,
+					StandardOpenOption.TRUNCATE_EXISTING,
+					StandardOpenOption.WRITE);
+		}
+		catch (final IOException exception) {
+			plugin.warning("[MojangNames] Could not save Mojang profiles!", exception);
+			return;
+		}
+		plugin.info("[MojangNames] Mojang profiles saved!");
+	}
+
+	/**
+	 * Returns the player's uuid based on their Mojang name.
+	 *
+	 * @param name The player's Mojang name.
+	 * @return Returns the player's uuid, or null.
+	 */
+	public static UUID getMojangUuid(final String name) {
+		if (Strings.isNullOrEmpty(name)) {
+			return null;
+		}
+		return PROFILES.get(name);
+	}
+
+	/**
+	 * <p>Returns the player's Mojang name based on their uuid.</p>
+	 *
+	 * <p>Note: The name will be lowercase.</p>
+	 *
+	 * @param uuid The player's uuid.
+	 * @return Returns the player's Mojang name, or null.
+	 */
+	public static String getMojangName(final UUID uuid) {
+		if (uuid == null) {
+			return null;
+		}
+		return MoreMapUtils.getKeyFromValue(PROFILES, uuid);
+	}
+
+	/**
+	 * DO NOT USE THIS ANYWHERE OTHER THAN {@link AssociationListener#OnPlayerLogin(PlayerLoginEvent)}
+	 *
+	 * @param uuid The player's uuid.
+	 * @param name The player's Mojang name.
+	 */
+	public static void declareMojangName(final UUID uuid, final String name) {
+		Preconditions.checkNotNull(uuid);
+		Preconditions.checkArgument(!Strings.isNullOrEmpty(name));
+		PROFILES.put(name, uuid);
+	}
+
+}

--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/MojangNames.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/MojangNames.java
@@ -2,7 +2,6 @@ package vg.civcraft.mc.namelayer;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import io.civrepo.commons.holders.MoreMapUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -16,6 +15,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.scheduler.BukkitTask;
 import vg.civcraft.mc.civmodcore.serialization.NBTCompound;
+import vg.civcraft.mc.civmodcore.util.MapUtils;
 import vg.civcraft.mc.namelayer.listeners.AssociationListener;
 
 public final class MojangNames {
@@ -103,7 +103,7 @@ public final class MojangNames {
 		if (uuid == null) {
 			return null;
 		}
-		return MoreMapUtils.getKeyFromValue(PROFILES, uuid);
+		return MapUtils.getKeyFromValue(PROFILES, uuid);
 	}
 
 	/**

--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/MojangNames.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/MojangNames.java
@@ -63,7 +63,7 @@ public final class MojangNames {
 
 	private static void save(final NameLayerPlugin plugin, final Path file) {
 		final NBTCompound nbt = new NBTCompound();
-		PROFILES.forEach(nbt::setUUID);
+		PROFILES.forEach((name, uuid) -> nbt.setUUID(name, uuid)); // Ignore highlighter
 		final byte[] data = NBTCompound.toBytes(nbt);
 		try {
 			Files.write(file, data,

--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/NameLayerPlugin.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/NameLayerPlugin.java
@@ -6,12 +6,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.logging.Level;
-
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
-
 import vg.civcraft.mc.civmodcore.ACivMod;
 import vg.civcraft.mc.civmodcore.dao.ManagedDatasource;
 import vg.civcraft.mc.namelayer.command.CommandHandler;
@@ -26,8 +24,8 @@ import vg.civcraft.mc.namelayer.misc.ClassHandler;
 import vg.civcraft.mc.namelayer.misc.NameCleanser;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
+public class NameLayerPlugin extends ACivMod {
 
-public class NameLayerPlugin extends ACivMod{
 	private static AssociationList associations;
 	private static BlackList blackList;
 	private static GroupManagerDao groupManagerDao;
@@ -55,6 +53,7 @@ public class NameLayerPlugin extends ACivMod{
 	    ClassHandler.Initialize(Bukkit.getServer());
 		new NameAPI(new GroupManager(), associations);
 		NameCleanser.load(config.getConfigurationSection("name_cleanser"));
+		MojangNames.init(this);
 		registerListeners();
 		if (loadGroups){
 			PermissionType.initialize();
@@ -68,8 +67,8 @@ public class NameLayerPlugin extends ACivMod{
 	}
 	
 	public void registerListeners(){
-		getServer().getPluginManager().registerEvents(new AssociationListener(), this);
-		getServer().getPluginManager().registerEvents(new PlayerListener(), this);
+		registerListener(new AssociationListener());
+		registerListener(new PlayerListener());
 	}
 	
 	@Override
@@ -88,6 +87,8 @@ public class NameLayerPlugin extends ACivMod{
 
 	@Override
 	public void onDisable() {
+		MojangNames.reset(this);
+		super.onDisable();
 	}
 	
 	public static NameLayerPlugin getInstance(){
@@ -229,4 +230,5 @@ public class NameLayerPlugin extends ACivMod{
 	public static DefaultGroupHandler getDefaultGroupHandler() {
 		return defaultGroupHandler;
 	}
+
 }

--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java
@@ -1,6 +1,7 @@
 package vg.civcraft.mc.namelayer.gui;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -111,89 +112,91 @@ public class PermissionManageGUI extends AbstractGroupGUI {
 		ClickableInventory ci = new ClickableInventory(54, g.getName());
 		final List<Clickable> clicks = new ArrayList<>();
 		final GroupPermission gp = gm.getPermissionforGroup(g);
-		for (final PermissionType perm : PermissionType.getAllPermissions()) {
-			ItemStack is = null;
-			Clickable c;
-			final boolean hasPerm = gp.hasPermission(pType, perm);
-			boolean canEdit = gm.hasAccess(g, p.getUniqueId(),
-					PermissionType.getPermission("PERMS"));
+		PermissionType.getAllPermissions().stream()
+				.sorted(Comparator.comparing(PermissionType::getName))
+				.forEachOrdered(perm -> {
+					ItemStack is = null;
+					Clickable c;
+					final boolean hasPerm = gp.hasPermission(pType, perm);
+					boolean canEdit = gm.hasAccess(g, p.getUniqueId(),
+							PermissionType.getPermission("PERMS"));
 
-			if (hasPerm) {
-				is = yesStack();
-				ItemAPI.addLore(
-						is,
-						ChatColor.DARK_AQUA
-								+ PlayerType.getNiceRankName(pType)
-								+ "s currently have", ChatColor.DARK_AQUA
-								+ "this permission");
-			} else {
-				is = noStack();
-				ItemAPI.addLore(
-						is,
-						ChatColor.DARK_AQUA
-								+ PlayerType.getNiceRankName(pType)
-								+ "s currently don't have", ChatColor.DARK_AQUA
-								+ "this permission");
-			}
-			ItemAPI.setDisplayName(is, perm.getName());
-			String desc = perm.getDescription();
-			if (desc != null) {
-				final int MAX_CHARS = 35;
-				String[] words = desc.split(" ");
-				StringBuilder line = new StringBuilder();
-				for  (int i = 0; i < words.length; i++) {
-					line.append(words[i]).append(" ");
-					if (line.length() >= MAX_CHARS || i == words.length - 1){
-						ItemAPI.addLore(is, ChatColor.GREEN + line.toString().trim());
-						line = new StringBuilder();
+					if (hasPerm) {
+						is = yesStack();
+						ItemAPI.addLore(
+								is,
+								ChatColor.DARK_AQUA
+										+ PlayerType.getNiceRankName(pType)
+										+ "s currently have", ChatColor.DARK_AQUA
+										+ "this permission");
+					} else {
+						is = noStack();
+						ItemAPI.addLore(
+								is,
+								ChatColor.DARK_AQUA
+										+ PlayerType.getNiceRankName(pType)
+										+ "s currently don't have", ChatColor.DARK_AQUA
+										+ "this permission");
 					}
-				}
-			}
-			if (pType == PlayerType.NOT_BLACKLISTED && !perm.getCanBeBlacklisted()) {
-				canEdit = false;
-
-				ItemAPI.addLore(
-						is,
-						ChatColor.AQUA
-								+ "This permission cannot be toggled for "
-								+ PlayerType.getNiceRankName(pType)
-				);
-			}
-
-			if (canEdit) {
-				ItemAPI.addLore(is, ChatColor.AQUA + "Click to toggle");
-				c = new Clickable(is) {
-
-					@Override
-					public void clicked(Player arg0) {
-						if (hasPerm == gp.hasPermission(pType, perm)) { // recheck
-							if (gm.hasAccess(g, p.getUniqueId(),
-									PermissionType.getPermission("PERMS"))) {
-								NameLayerPlugin.log(Level.INFO, p.getName()
-										+ (hasPerm ? " removed " : " added ")
-										+ "the permission " + perm.getName()
-										+ "for player type " + pType.toString()
-										+ " for " + g.getName() + " via the gui");
-								if (hasPerm) {
-									gp.removePermission(pType, perm);
-								} else {
-									gp.addPermission(pType, perm);
-								}
+					ItemAPI.setDisplayName(is, perm.getName());
+					String desc = perm.getDescription();
+					if (desc != null) {
+						final int MAX_CHARS = 35;
+						String[] words = desc.split(" ");
+						StringBuilder line = new StringBuilder();
+						for  (int i = 0; i < words.length; i++) {
+							line.append(words[i]).append(" ");
+							if (line.length() >= MAX_CHARS || i == words.length - 1){
+								ItemAPI.addLore(is, ChatColor.GREEN + line.toString().trim());
+								line = new StringBuilder();
 							}
-						} else {
-							p.sendMessage(ChatColor.RED
-									+ "Something changed while you were modifying permissions, so cancelled the process");
 						}
-						showPermissionEditing(pType);
 					}
-				};
-			} else {
-				c = new DecorationStack(is);
-			}
-			clicks.add(c);
-		}
-		for (int i = 45 * currentPage; i < 45 * (currentPage + 1)
-				&& i < clicks.size(); i++) {
+					if (pType == PlayerType.NOT_BLACKLISTED && !perm.getCanBeBlacklisted()) {
+						canEdit = false;
+
+						ItemAPI.addLore(
+								is,
+								ChatColor.AQUA
+										+ "This permission cannot be toggled for "
+										+ PlayerType.getNiceRankName(pType)
+						);
+					}
+
+					if (canEdit) {
+						ItemAPI.addLore(is, ChatColor.AQUA + "Click to toggle");
+						c = new Clickable(is) {
+
+							@Override
+							public void clicked(Player arg0) {
+								if (hasPerm == gp.hasPermission(pType, perm)) { // recheck
+									if (gm.hasAccess(g, p.getUniqueId(),
+											PermissionType.getPermission("PERMS"))) {
+										NameLayerPlugin.log(Level.INFO, p.getName()
+												+ (hasPerm ? " removed " : " added ")
+												+ "the permission " + perm.getName()
+												+ "for player type " + pType.toString()
+												+ " for " + g.getName() + " via the gui");
+										if (hasPerm) {
+											gp.removePermission(pType, perm);
+										} else {
+											gp.addPermission(pType, perm);
+										}
+									}
+								} else {
+									p.sendMessage(ChatColor.RED
+											+ "Something changed while you were modifying permissions, so cancelled the process");
+								}
+								showPermissionEditing(pType);
+							}
+						};
+					} else {
+						c = new DecorationStack(is);
+					}
+					clicks.add(c);
+				});
+
+		for (int i = 45 * currentPage; i < 45 * (currentPage + 1) && i < clicks.size(); i++) {
 			ci.setSlot(clicks.get(i), i - (45 * currentPage));
 		}
 

--- a/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/listeners/AssociationListener.java
+++ b/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/listeners/AssociationListener.java
@@ -1,15 +1,15 @@
 package vg.civcraft.mc.namelayer.listeners;
 
 import java.util.UUID;
-
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
-
+import vg.civcraft.mc.namelayer.MojangNames;
 import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.NameLayerPlugin;
 import vg.civcraft.mc.namelayer.database.AssociationList;
@@ -62,14 +62,16 @@ public class AssociationListener implements Listener {
 
 	@EventHandler(priority = EventPriority.LOWEST)
 	public void OnPlayerLogin(PlayerLoginEvent event) {
-		String name = associations.getCurrentName(event.getPlayer().getUniqueId());
+		final Player player = event.getPlayer();
+		MojangNames.declareMojangName(player.getUniqueId(), player.getName());
+		String name = associations.getCurrentName(player.getUniqueId());
 		if (name == null)
 		{
-			associations.addPlayer(event.getPlayer().getName(), event.getPlayer().getUniqueId());
-			name = associations.getCurrentName(event.getPlayer().getUniqueId());
+			associations.addPlayer(player.getName(), player.getUniqueId());
+			name = associations.getCurrentName(player.getUniqueId());
 		}
 
 		if (game != null)
-			game.setPlayerProfle(event.getPlayer(), name);
+			game.setPlayerProfle(player, name);
 	}
 }


### PR DESCRIPTION
Added persistent Mojang name caching, plus changed the permission GUI to sort permissions alphabetically. The permission GUI diff looks rather scary, but if you [look here](https://github.com/CivClassic/NameLayer/blob/1fe8bf2ff1a7c4f4f031af10727748d7334d8379/namelayer-spigot/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java#L117) it's exactly the same as before but inside a sorted for each instead of a for loop.